### PR TITLE
Floating point primitive

### DIFF
--- a/bindgen/c.ml
+++ b/bindgen/c.ml
@@ -1,7 +1,7 @@
 let caml_ = "caml_"
 
 type c_type = Prim of string | Struct of string | Ptr of c_type | Void
-type c_prim = Int of int | Str of string
+type c_prim = Int of int | Float of float | Str of string
 
 type t =
   | C_function of {
@@ -22,7 +22,6 @@ type t =
   | C_include of string
 
 type program = t list
-
 
 let pp_list sep pp_el fmt t =
   Format.pp_print_list
@@ -66,6 +65,7 @@ and pp_type fmt (ctype : c_type) =
 and pp_prim fmt (prim : c_prim) =
   match prim with
   | Int d -> Format.fprintf fmt "%d" d
+  | Float f -> Format.fprintf fmt "%f" f
   | Str s -> Format.fprintf fmt "%s" s
 
 let decl dcl_type dcl_name dcl_value = C_decl { dcl_name; dcl_type; dcl_value }
@@ -73,6 +73,7 @@ let call cc_name cc_args = C_call { cc_name; cc_args }
 let var x = C_variable x
 let assign asg_var asg_value = C_assign { asg_var; asg_value }
 let int x = C_prim (Int x)
+let float f = C_prim (Float f)
 let string x = C_prim (Str x)
 let ptr_field pfa_name pfa_field = C_ptr_field_access { pfa_name; pfa_field }
 let typ t = C_type t
@@ -90,7 +91,11 @@ let caml_alloc_tuple fields =
 
 let store_field var idx value = call "Store_field" [ var; int idx; value ]
 let val_int var name = call "Val_int" [ ptr_field var name ]
-let int_val var idx = call "Int_val" [ call "Field" [ var; int idx] ]
+let int_val var idx = call "Int_val" [ call "Field" [ var; int idx ] ]
+
+(* Unlike Int, Float must be re-boxed before returning to the OCaml runtime thus a copy*)
+let val_float var name = call "caml_copy_double" [ ptr_field var name ]
+let float_val var idx = call "Double_val" [ call "Field" [ var; int idx ] ]
 
 (* from_ir *)
 let rec ctype_of_ir (ir_type : Ir.ir_type) =
@@ -99,6 +104,7 @@ let rec ctype_of_ir (ir_type : Ir.ir_type) =
   | Ir.Record { rec_name; _ } -> Prim rec_name
   | Ir.Enum { enum_name; _ } -> Prim enum_name
   | Ir.Prim Ir.Int -> Prim "int"
+  | Ir.Prim Ir.Float -> Prim "float"
   | Ir.Prim Ir.Bool -> Prim "bool"
   | Ir.Prim Ir.Char -> Prim "char"
   | Ir.Prim Ir.Void -> Void
@@ -127,9 +133,13 @@ module Shims = struct
           ]
           @ Ir.(
               List.mapi
-                (fun idx field ->
-                  store_field (var "caml_x") idx
-                    (val_int (var "x") field.fld_name))
+                (fun idx fld ->
+                  let fld_caml_value =
+                    match fld.fld_type with
+                    | Prim Float -> val_float (var "x") fld.fld_name
+                    | _ -> val_int (var "x") fld.fld_name
+                  in
+                  store_field (var "caml_x") idx fld_caml_value)
                 fields)
           @ [ caml_return (var "caml_x") ];
       }
@@ -148,9 +158,12 @@ module Shims = struct
           @ Ir.(
               List.mapi
                 (fun idx fld ->
-                  assign
-                    (ptr_field (var "x") fld.fld_name)
-                    (int_val (var "caml_x") idx))
+                  let field_c_value =
+                    match fld.fld_type with
+                    | Prim Float -> float_val (var "caml_x") idx
+                    | _ -> int_val (var "caml_x") idx
+                  in
+                  assign (ptr_field (var "x") fld.fld_name) field_c_value)
                 fields)
           @ [ return (var "x") ];
       }
@@ -162,7 +175,10 @@ module Shims = struct
 
         let fn_body =
           let declare_params =
-            [ caml_params (List.map (fun (name, _type) -> var (caml_^name)) fn_params ) ]
+            [
+              caml_params
+                (List.map (fun (name, _type) -> var (caml_ ^ name)) fn_params);
+            ]
           in
           let maybe_declare_result =
             match fn_ret with
@@ -224,17 +240,16 @@ let from_ir (ir : Ir.t) : program =
     C_include "<caml/mlvalues.h>";
     C_include "<caml/unixsupport.h>";
   ]
-  @
-  (List.filter_map
-    (fun node ->
-      match node with
-      | Ir.Ir_fun_decl fun_decl -> Some [ Shims.wrap_fun fun_decl ]
-      | Ir.Ir_type (Record { rec_name; rec_fields }) ->
-          Some
-            [
-              Shims.of_value rec_name rec_fields;
-              Shims.to_value rec_name rec_fields;
-            ]
-      | _ -> None)
-    ir.items
-  |> List.flatten)
+  @ (List.filter_map
+       (fun node ->
+         match node with
+         | Ir.Ir_fun_decl fun_decl -> Some [ Shims.wrap_fun fun_decl ]
+         | Ir.Ir_type (Record { rec_name; rec_fields }) ->
+             Some
+               [
+                 Shims.of_value rec_name rec_fields;
+                 Shims.to_value rec_name rec_fields;
+               ]
+         | _ -> None)
+       ir.items
+    |> List.flatten)

--- a/bindgen/c.ml
+++ b/bindgen/c.ml
@@ -93,7 +93,6 @@ let store_field var idx value = call "Store_field" [ var; int idx; value ]
 let val_int var name = call "Val_int" [ ptr_field var name ]
 let int_val var idx = call "Int_val" [ call "Field" [ var; int idx ] ]
 
-(* Unlike Int, Float must be re-boxed before returning to the OCaml runtime thus a copy*)
 let val_float var name = call "caml_copy_double" [ ptr_field var name ]
 let float_val var idx = call "Double_val" [ call "Field" [ var; int idx ] ]
 

--- a/bindgen/caml.ml
+++ b/bindgen/caml.ml
@@ -28,6 +28,7 @@ let rec core_type_from_ir typ =
   | Ir.Enum { enum_name; _ } -> Typ.constr (lid enum_name) []
   | Ir.Record { rec_name; _ } -> Typ.constr (lid rec_name) []
   | Ir.Prim Int -> Typ.constr (lid "int") []
+  | Ir.Prim Float -> Typ.constr (lid "float") []
   | Ir.Prim Bool -> Typ.constr (lid "bool") []
   | Ir.Prim Char -> Typ.constr (lid "char") []
   | Ir.Prim Void -> Typ.constr (lid "unit") []

--- a/bindgen/ir.ml
+++ b/bindgen/ir.ml
@@ -1,4 +1,4 @@
-type ir_prim_type = Int | Bool | Char | Void
+type ir_prim_type = Int | Float | Bool | Char | Void
 
 type ir_type =
   | Abstract of string
@@ -23,6 +23,7 @@ module Lift = struct
     (* Format.printf "lift_type: %S\n" (Clang.Type.show typ); *)
     match typ.desc with
     | Clang.Ast.BuiltinType Int -> Prim Int
+    | Clang.Ast.BuiltinType Float -> Prim Float
     | Clang.Ast.BuiltinType Bool -> Prim Bool
     | Clang.Ast.BuiltinType Char_S -> Prim Char
     | Clang.Ast.BuiltinType Void -> Prim Void

--- a/bindgen/ir.ml
+++ b/bindgen/ir.ml
@@ -24,6 +24,7 @@ module Lift = struct
     match typ.desc with
     | Clang.Ast.BuiltinType Int -> Prim Int
     | Clang.Ast.BuiltinType Float -> Prim Float
+    | Clang.Ast.BuiltinType Double -> Prim Float
     | Clang.Ast.BuiltinType Bool -> Prim Bool
     | Clang.Ast.BuiltinType Char_S -> Prim Char
     | Clang.Ast.BuiltinType Void -> Prim Void

--- a/examples/caml_doggo.c
+++ b/examples/caml_doggo.c
@@ -11,16 +11,18 @@ Doggo* caml_Doggo_of_value(value caml_x) {
   x->many = Int_val(Field(caml_x, 0));
   x->breed = Int_val(Field(caml_x, 1));
   x->wow = Int_val(Field(caml_x, 2));
+  x->weight = Double_val(Field(caml_x, 3));
   return x;
 }
 
 value caml_Doggo_to_value(struct Doggo* x) {
   CAMLparam0();
   CAMLlocal1(caml_x);
-  caml_x = caml_alloc_tuple(3);
+  caml_x = caml_alloc_tuple(4);
   Store_field(caml_x, 0, Val_int(x->many));
   Store_field(caml_x, 1, Val_int(x->breed));
   Store_field(caml_x, 2, Val_int(x->wow));
+  Store_field(caml_x, 3, caml_copy_double(x->weight));
   CAMLreturn(caml_x);
 }
 

--- a/examples/doggo.c
+++ b/examples/doggo.c
@@ -11,5 +11,5 @@ static const char* BreedToString[4] = {
 void eleven_out_of_ten_majestic_af(Doggo* pupper) {
   printf("doggo says %d\n", pupper->many);
   printf("doggo is a %s\n", BreedToString[pupper->breed]);
+  printf("doggo weighs %.1fkg\n", pupper->weight);
 }
-

--- a/examples/doggo.h
+++ b/examples/doggo.h
@@ -9,6 +9,7 @@ typedef struct Doggo {
     int many;
     breed breed;
     char wow;
+    float weight;
 } Doggo;
 
 void eleven_out_of_ten_majestic_af(Doggo* pupper);

--- a/examples/doggo.ml
+++ b/examples/doggo.ml
@@ -7,6 +7,7 @@ type nonrec breed =
 type nonrec doggo = {
   many: int ;
   breed: breed ;
-  wow: char }
+  wow: char ;
+  weight: float }
 external eleven_out_of_ten_majestic_af :
   pupper:doggo -> unit = "caml_eleven_out_of_ten_majestic_af"

--- a/examples/main.ml
+++ b/examples/main.ml
@@ -1,5 +1,11 @@
-Doggo.eleven_out_of_ten_majestic_af ~pupper:{
+open Doggo
+
+let pupper = {
   many=2112;
   wow='x';
-  breed=C_Labrador
+  breed=C_Labrador;
+  weight=18.9;
 }
+
+let () =
+  Doggo.eleven_out_of_ten_majestic_af ~pupper


### PR DESCRIPTION
Addresses https://github.com/ocaml-sys/ocaml-bindgen/issues/9

#### Overview

Threads the basic Float and Double primitives from libclang through the IR and then c/caml generation.
 
#### Features

- Adds a `float` into the doggo example
- Get the C value (it automatically is casted from double to float since OCaml doesnt have 32bit floats AFAIK) with `Double_val`
- If returning a struct back to OCaml we need it to be boxed and so the `caml_copy_double` function is used (just referenced the docs for this :) )

#### Future Improvements

I decided to just leave the fallback to `val_int` and `int_val` for now because if we want to do more intelligent matching there we probably need a way of either bubbling up errors or raising an exception and I don't want to touch that right now without having a proper discussion with you & others.

----

I'm going to test out type aliases next (I usually typedef float and double to f32/f64 respectively for example).