### PR TITLE
Parameter-less C function calls

### DIFF
--- a/examples/caml_doggo.c
+++ b/examples/caml_doggo.c
@@ -31,4 +31,10 @@ void caml_eleven_out_of_ten_majestic_af(value caml_pupper) {
   CAMLreturn0;
 }
 
+void caml_no_input_no_output() {
+  CAMLparam0();
+  no_input_no_output();
+  CAMLreturn0;
+}
+
 

--- a/examples/doggo.c
+++ b/examples/doggo.c
@@ -13,3 +13,6 @@ void eleven_out_of_ten_majestic_af(Doggo* pupper) {
   printf("doggo is a %s\n", BreedToString[pupper->breed]);
 }
 
+void no_input_no_output(void) {
+  printf("We are doing nothing (of importance)\n");
+}

--- a/examples/doggo.h
+++ b/examples/doggo.h
@@ -12,3 +12,5 @@ typedef struct Doggo {
 } Doggo;
 
 void eleven_out_of_ten_majestic_af(Doggo* pupper);
+
+void no_input_no_output(void);

--- a/examples/doggo.ml
+++ b/examples/doggo.ml
@@ -10,3 +10,4 @@ type nonrec doggo = {
   wow: char }
 external eleven_out_of_ten_majestic_af :
   pupper:doggo -> unit = "caml_eleven_out_of_ten_majestic_af"
+external no_input_no_output : unit -> unit = "caml_no_input_no_output"


### PR DESCRIPTION
Addresses https://github.com/ocaml-sys/ocaml-bindgen/issues/12 by matching on the function declaration IR and if it has no parameters we inject a `unit ->` with no label.

Output is
```ocaml
external no_input_no_output : unit -> unit = "caml_no_input_no_output"
```
and compiles happily :)

Note: I added a function to `doggo.h` that isn't really dog related but I feel that this library has a decent way to go before being production ready and so I think we can add a example testbed later that just has random code with no theme.