### PR TITLE
public_name stanza

### DIFF
--- a/bindgen/dune
+++ b/bindgen/dune
@@ -1,4 +1,5 @@
 (library
+ (public_name bindgen)
  (name bindgen)
  (preprocess
   (pps ppxlib.metaquot))


### PR DESCRIPTION
This is necessary for [genie](https://github.com/omnisci3nce/genie) to rely on `ocaml-bindgen` as a dependency.